### PR TITLE
Reduce contention in netx (and thereby tlsproxy) by not type casting

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -17,21 +17,18 @@ var (
 )
 
 // BidiCopy copies between in and out in both directions using the specified
-// buffers, returning the errors from copying to out and copying to in. BidiCopy
-// continues trying to write out to the respective connections for up to
-// writeTimeout to flush any buffered data before giving up and returning
-// io.ErrShortWrite.
-func BidiCopy(out net.Conn, in net.Conn, bufOut []byte, bufIn []byte, writeTimeout time.Duration) (outErr error, inErr error) {
+// buffers, returning the errors from copying to out and copying to in.
+func BidiCopy(out net.Conn, in net.Conn, bufOut []byte, bufIn []byte) (outErr error, inErr error) {
 	stop := uint32(0)
 	outErrCh := make(chan error, 1)
 	inErrCh := make(chan error, 1)
-	go doCopy(out, in, bufIn, writeTimeout, outErrCh, &stop)
-	go doCopy(in, out, bufOut, writeTimeout, inErrCh, &stop)
+	go doCopy(out, in, bufIn, outErrCh, &stop)
+	go doCopy(in, out, bufOut, inErrCh, &stop)
 	return <-outErrCh, <-inErrCh
 }
 
 // doCopy is based on io.copyBuffer
-func doCopy(dst net.Conn, src net.Conn, buf []byte, writeTimeout time.Duration, errCh chan error, stop *uint32) {
+func doCopy(dst net.Conn, src net.Conn, buf []byte, errCh chan error, stop *uint32) {
 	var err error
 	defer func() {
 		atomic.StoreUint32(stop, 1)
@@ -46,7 +43,6 @@ func doCopy(dst net.Conn, src net.Conn, buf []byte, writeTimeout time.Duration, 
 		}
 		nr, er := src.Read(buf)
 		if nr > 0 {
-			dst.SetWriteDeadline(time.Now().Add(writeTimeout))
 			nw, ew := dst.Write(buf[0:nr])
 			if err != nil {
 				err = ew

--- a/copy.go
+++ b/copy.go
@@ -66,24 +66,6 @@ func doCopy(dst net.Conn, src net.Conn, buf []byte, writeTimeout time.Duration, 
 	}
 }
 
-func writeTo(dst net.Conn, buf []byte, writeTimeout time.Duration) error {
-	nw := 0
-	writeStart := time.Now()
-	for {
-		nww, err := dst.Write(buf)
-		nw += nww
-		if err != nil && !isTimeout(err) {
-			return err
-		}
-		if nw == len(buf) {
-			return nil
-		}
-		if time.Now().Sub(writeStart) > writeTimeout {
-			return io.ErrShortWrite
-		}
-	}
-}
-
 func isTimeout(err error) bool {
 	if netErr, ok := err.(net.Error); ok {
 		return netErr.Timeout()

--- a/copy.go
+++ b/copy.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+const (
+	ioTimeout       = "i/o timeout"
+	ioTimeoutLength = 11
+)
+
 var (
 	copyTimeout = 1 * time.Second
 )
@@ -67,8 +72,7 @@ func doCopy(dst net.Conn, src net.Conn, buf []byte, writeTimeout time.Duration, 
 }
 
 func isTimeout(err error) bool {
-	if netErr, ok := err.(net.Error); ok {
-		return netErr.Timeout()
-	}
-	return false
+	es := err.Error()
+	esl := len(es)
+	return esl >= ioTimeoutLength && es[esl-ioTimeoutLength:] == ioTimeout
 }

--- a/copy.go
+++ b/copy.go
@@ -43,11 +43,10 @@ func doCopy(dst net.Conn, src net.Conn, buf []byte, writeTimeout time.Duration, 
 		stopping := atomic.LoadUint32(stop) == 1
 		if stopping {
 			src.SetReadDeadline(time.Now().Add(copyTimeout))
-		} else {
-			src.SetReadDeadline(time.Now().Add(writeTimeout))
 		}
 		nr, er := src.Read(buf)
 		if nr > 0 {
+			dst.SetWriteDeadline(time.Now().Add(writeTimeout))
 			nw, ew := dst.Write(buf[0:nr])
 			if err != nil {
 				err = ew

--- a/copy.go
+++ b/copy.go
@@ -43,6 +43,8 @@ func doCopy(dst net.Conn, src net.Conn, buf []byte, writeTimeout time.Duration, 
 		stopping := atomic.LoadUint32(stop) == 1
 		if stopping {
 			src.SetReadDeadline(time.Now().Add(copyTimeout))
+		} else {
+			src.SetReadDeadline(time.Now().Add(writeTimeout))
 		}
 		nr, er := src.Read(buf)
 		if nr > 0 {

--- a/copy_test.go
+++ b/copy_test.go
@@ -23,8 +23,6 @@ func TestSimulatedProxy(t *testing.T) {
 		data[i] = 5
 	}
 
-	writeTimeout := 100 * time.Millisecond
-
 	_, fdc, err := fdcount.Matching("TCP")
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +75,7 @@ func TestSimulatedProxy(t *testing.T) {
 		}
 		defer out.Close()
 
-		errOut, errIn := BidiCopy(out, in, make([]byte, 32768), make([]byte, 32768), writeTimeout)
+		errOut, errIn := BidiCopy(out, in, make([]byte, 32768), make([]byte, 32768))
 		assert.NoError(t, errOut, "Error copying to server")
 		assert.NoError(t, errIn, "Error copying to client")
 		wg.Done()

--- a/copy_test.go
+++ b/copy_test.go
@@ -13,17 +13,17 @@ import (
 )
 
 func TestSimulatedProxy(t *testing.T) {
-	originalCopyTimeout := copyTimeout
-	copyTimeout = 5 * time.Millisecond
-	defer func() {
-		copyTimeout = originalCopyTimeout
-	}()
+	// originalCopyTimeout := copyTimeout
+	// copyTimeout = 5 * time.Millisecond
+	// defer func() {
+	// 	copyTimeout = originalCopyTimeout
+	// }()
 	data := make([]byte, 30000000)
 	for i := 0; i < len(data); i++ {
 		data[i] = 5
 	}
 
-	writeTimeout := copyTimeout * 25
+	writeTimeout := 100 * time.Millisecond
 
 	_, fdc, err := fdcount.Matching("TCP")
 	if err != nil {

--- a/timeout_bench_test.go
+++ b/timeout_bench_test.go
@@ -1,0 +1,94 @@
+package netx
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"testing"
+)
+
+type timeouterror struct {
+}
+
+func (t *timeouterror) Error() string {
+	return ioTimeout
+}
+
+func (t *timeouterror) Timeout() bool {
+	return true
+}
+
+func (t *timeouterror) Temporary() bool {
+	return false
+}
+
+// This is the slowest
+func BenchmarkTimeoutUsingCast(b *testing.B) {
+	var err error = &timeouterror{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err.(net.Error).Timeout() {
+		}
+	}
+}
+
+// This is surprisingly slow
+func BenchmarkTimeoutUsingBytesEquals(b *testing.B) {
+	var err error = &timeouterror{}
+	ioTimeoutBytes := []byte(ioTimeout)
+	iotl := len(ioTimeoutBytes)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		es := []byte(err.Error())
+		esl := len(es)
+		if esl >= iotl && bytes.Equal(es[esl-ioTimeoutLength:], ioTimeoutBytes) {
+		}
+	}
+}
+
+// This is also surprisingly slow
+func BenchmarkTimeoutUsingHandBuiltCompare(b *testing.B) {
+	var err error = &timeouterror{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		es := err.Error()
+		if hasSuffix(es, ioTimeout, ioTimeoutLength) {
+		}
+	}
+}
+
+// This is faster
+func BenchmarkTimeoutUsingSuffix(b *testing.B) {
+	var err error = &timeouterror{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		es := err.Error()
+		if strings.HasSuffix(es, ioTimeout) {
+		}
+	}
+}
+
+// This is fastest
+func BenchmarkTimeoutUsingSliceCompare(b *testing.B) {
+	var err error = &timeouterror{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		es := err.Error()
+		esl := len(es)
+		if esl >= ioTimeoutLength && es[esl-ioTimeoutLength:] == ioTimeout {
+		}
+	}
+}
+
+func hasSuffix(a string, b string, l int) bool {
+	delta := len(a) - l
+	if delta < 0 {
+		return false
+	}
+	for i := 0; i < l; i++ {
+		if a[i+delta] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/timeout_bench_test.go
+++ b/timeout_bench_test.go
@@ -69,6 +69,17 @@ func BenchmarkTimeoutUsingHandBuiltCompare(b *testing.B) {
 	}
 }
 
+// Surprisingly slow
+func BenchmarkTimeoutUsingInterfaceEqualCheck(b *testing.B) {
+	var err error = &timeouterror{}
+	err2 := err
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err == err2 {
+		}
+	}
+}
+
 // This is faster
 func BenchmarkTimeoutUsingSuffix(b *testing.B) {
 	var err error = &timeouterror{}
@@ -92,13 +103,24 @@ func BenchmarkTimeoutUsingSliceCompare(b *testing.B) {
 	}
 }
 
-// This is fastest
+// This is very fast
 func BenchmarkTimeoutUsingConcreteCast(b *testing.B) {
 	var err error = &timeouterror{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, ok := err.(*timeouterror)
 		if ok {
+		}
+	}
+}
+
+// This is the fastest
+func BenchmarkTimeoutUsingConcreteEqualCheck(b *testing.B) {
+	err := &timeouterror{}
+	err2 := err
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err == err2 {
 		}
 	}
 }


### PR DESCRIPTION
I turns out that type casting is both expensive and creates lock contention in systems with lots of connections (see benchmarks).
