### PR TITLE
Add dialUDP

### DIFF
--- a/netx.go
+++ b/netx.go
@@ -23,12 +23,12 @@ func init() {
 }
 
 // Dial is like DialTimeout using a default timeout of 1 minute.
-func Dial(net string, addr string) (net.Conn, error) {
-	return DialTimeout(net, addr, defaultDialTimeout)
+func Dial(network string, addr string) (net.Conn, error) {
+	return DialTimeout(network, addr, defaultDialTimeout)
 }
 
-func DialUDP(net string, laddr, raddr *UDPAddr) (*UDPConn, error) {
-	return dialUDP.Load().(func(string, laddr, raddr *UDPAddr) (*net.UDPConn, error))(net, laddr, raddr)
+func DialUDP(network string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error) {
+	return dialUDP.Load().(func(string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error))(network, laddr, raddr)
 }
 
 // DialTimeout dials the given addr on the given net type using the configured
@@ -69,7 +69,7 @@ func ResolveUDP(network string, addr string) (*net.UDPAddr, error) {
 	return resolveUDPAddr.Load().(func(string, string) (*net.UDPAddr, error))(network, addr)
 }
 
-func OverrideResolveUDP(resolveFN func(net string, addr string) (*net.UDPAddr, error)) {
+func OverrideUDPResolve(resolveFN func(net string, addr string) (*net.UDPAddr, error)) {
 	resolveUDPAddr.Store(resolveFN)
 }
 

--- a/netx.go
+++ b/netx.go
@@ -74,8 +74,8 @@ func OverrideUDPResolve(resolveFN func(net string, addr string) (*net.UDPAddr, e
 }
 
 func SetDefaultUDPDial() {
-	dialFN := func(net string, laddr, raddr *net.UDPAddr) (net.Conn, error) {
-		conn, err := net.DialUDP(net, laddr, raddr)
+	dialFN := func(network string, laddr, raddr *net.UDPAddr) (net.Conn, error) {
+		conn, err := net.DialUDP(network, laddr, raddr)
 		return conn, err
 	}
 	dialUDP.Store(dialFN)

--- a/netx.go
+++ b/netx.go
@@ -73,11 +73,19 @@ func OverrideUDPResolve(resolveFN func(net string, addr string) (*net.UDPAddr, e
 	resolveUDPAddr.Store(resolveFN)
 }
 
+func SetDefaultUDPDial() {
+	dialFN := func(net string, laddr, raddr *net.UDPAddr) (net.Conn, error) {
+		conn, err := net.DialUDP(net, laddr, raddr)
+		return conn, err
+	}
+	dialUDP.Store(dialFN)
+}
+
 // Reset resets netx to its default settings
 func Reset() {
 	var d net.Dialer
 	OverrideDial(d.DialContext)
-	OverrideUDPDial(net.DialUDP)
+	SetDefaultUDPDial()
 	OverrideResolve(net.ResolveTCPAddr)
 	OverrideUDPResolve(net.ResolveUDPAddr)
 }

--- a/netx.go
+++ b/netx.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"sync/atomic"
 	"time"
+
+	"github.com/getlantern/golog"
 )
 
 var (
@@ -16,6 +18,8 @@ var (
 	resolveUDPAddr atomic.Value
 
 	defaultDialTimeout = 1 * time.Minute
+
+	log = golog.LoggerFor("netx")
 )
 
 func init() {
@@ -24,11 +28,13 @@ func init() {
 
 // Dial is like DialTimeout using a default timeout of 1 minute.
 func Dial(network string, addr string) (net.Conn, error) {
+	log.Debugf("Dialing (%s) %s", network, addr)
 	return DialTimeout(network, addr, defaultDialTimeout)
 }
 
 // DialUDP acts like Dial but for UDP networks.
 func DialUDP(network string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error) {
+	log.Debugf("Dialing (%s) %v", network, raddr)
 	return dialUDP.Load().(func(string, *net.UDPAddr, *net.UDPAddr) (*net.UDPConn, error))(network, laddr, raddr)
 }
 

--- a/netx.go
+++ b/netx.go
@@ -28,7 +28,7 @@ func Dial(network string, addr string) (net.Conn, error) {
 }
 
 func DialUDP(network string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error) {
-	return dialUDP.Load().(func(string, *net.UDPAddr, *net.UDPAddr) (*net.UDPConn, error))(network, laddr, raddr)
+	return dialUDP.Load().(func(string, *net.UDPAddr, *net.UDPAddr) (net.Conn, error))(network, laddr, raddr)
 }
 
 // DialTimeout dials the given addr on the given net type using the configured
@@ -51,7 +51,7 @@ func OverrideDial(dialFN func(ctx context.Context, net string, addr string) (net
 	dial.Store(dialFN)
 }
 
-func OverrideUDPDial(dialFN func(net string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error)) {
+func OverrideUDPDial(dialFN func(net string, laddr, raddr *net.UDPAddr) (net.Conn, error)) {
 	dialUDP.Store(dialFN)
 }
 

--- a/netx.go
+++ b/netx.go
@@ -77,6 +77,7 @@ func OverrideUDPResolve(resolveFN func(net string, addr string) (*net.UDPAddr, e
 func Reset() {
 	var d net.Dialer
 	OverrideDial(d.DialContext)
+	OverrideUDPDial(net.DialUDP)
 	OverrideResolve(net.ResolveTCPAddr)
 	OverrideUDPResolve(net.ResolveUDPAddr)
 }

--- a/netx.go
+++ b/netx.go
@@ -28,7 +28,7 @@ func Dial(network string, addr string) (net.Conn, error) {
 }
 
 func DialUDP(network string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error) {
-	return dialUDP.Load().(func(string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error))(network, laddr, raddr)
+	return dialUDP.Load().(func(string, *net.UDPAddr, *net.UDPAddr) (*net.UDPConn, error))(network, laddr, raddr)
 }
 
 // DialTimeout dials the given addr on the given net type using the configured

--- a/netx.go
+++ b/netx.go
@@ -77,7 +77,6 @@ func OverrideUDPResolve(resolveFN func(net string, addr string) (*net.UDPAddr, e
 func Reset() {
 	var d net.Dialer
 	OverrideDial(d.DialContext)
-	OverrideUDPDial(net.DialUDP)
 	OverrideResolve(net.ResolveTCPAddr)
 	OverrideUDPResolve(net.ResolveUDPAddr)
 }

--- a/netx.go
+++ b/netx.go
@@ -51,7 +51,7 @@ func OverrideDial(dialFN func(ctx context.Context, net string, addr string) (net
 	dial.Store(dialFN)
 }
 
-func OverrideDialUDP(dialFN func(net string, laddr, raddr *net.UDPAddr) (net.Conn, error)) {
+func OverrideDialUDP(dialFN func(net string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error)) {
 	dialUDP.Store(dialFN)
 }
 

--- a/netx.go
+++ b/netx.go
@@ -27,6 +27,7 @@ func Dial(network string, addr string) (net.Conn, error) {
 	return DialTimeout(network, addr, defaultDialTimeout)
 }
 
+// DialUDP acts like Dial but for UDP networks.
 func DialUDP(network string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error) {
 	return dialUDP.Load().(func(string, *net.UDPAddr, *net.UDPAddr) (*net.UDPConn, error))(network, laddr, raddr)
 }
@@ -51,6 +52,7 @@ func OverrideDial(dialFN func(ctx context.Context, net string, addr string) (net
 	dial.Store(dialFN)
 }
 
+// OverrideDialUDP overrides the global dialUDP function.
 func OverrideDialUDP(dialFN func(net string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error)) {
 	dialUDP.Store(dialFN)
 }
@@ -69,6 +71,7 @@ func OverrideResolve(resolveFN func(net string, addr string) (*net.TCPAddr, erro
 	resolveTCPAddr.Store(resolveFN)
 }
 
+// OverrideResolveUDP overrides the global resolveUDP function.
 func OverrideResolveUDP(resolveFN func(net string, addr string) (*net.UDPAddr, error)) {
 	resolveUDPAddr.Store(resolveFN)
 }

--- a/netx.go
+++ b/netx.go
@@ -62,7 +62,7 @@ func Resolve(network string, addr string) (*net.TCPAddr, error) {
 	return resolveTCPAddr.Load().(func(string, string) (*net.TCPAddr, error))(network, addr)
 }
 
-func ResolveUDP(network string, addr string) (*net.UDPAddr, error) {
+func ResolveUDPAddr(network string, addr string) (*net.UDPAddr, error) {
 	return resolveUDPAddr.Load().(func(string, string) (*net.UDPAddr, error))(network, addr)
 }
 

--- a/netx.go
+++ b/netx.go
@@ -27,7 +27,7 @@ func Dial(network string, addr string) (net.Conn, error) {
 	return DialTimeout(network, addr, defaultDialTimeout)
 }
 
-func DialUDP(network string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error) {
+func DialUDP(network string, laddr, raddr *net.UDPAddr) (net.Conn, error) {
 	return dialUDP.Load().(func(string, *net.UDPAddr, *net.UDPAddr) (net.Conn, error))(network, laddr, raddr)
 }
 

--- a/netx.go
+++ b/netx.go
@@ -28,7 +28,7 @@ func Dial(network string, addr string) (net.Conn, error) {
 }
 
 func DialUDP(network string, laddr, raddr *net.UDPAddr) (*net.UDPConn, error) {
-	return dialUDP.Load().(func(string, *net.UDPAddr, *net.UDPAddr) (*net.Conn, error))(network, laddr, raddr)
+	return dialUDP.Load().(func(string, *net.UDPAddr, *net.UDPAddr) (*net.UDPConn, error))(network, laddr, raddr)
 }
 
 // DialTimeout dials the given addr on the given net type using the configured


### PR DESCRIPTION
These changes, and some updates to the `protected` package, are to allow dialing a UDP network over a protected socket. To support KCP on mobile, we can exclude the connection to the KCP server from the VPN by using `netx.DialUDP` here: https://github.com/getlantern/kcp-go/blob/master/sess.go#L924