### PR TITLE
add slow robust path to isTimeout

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -81,5 +81,11 @@ func doCopy(dst net.Conn, src net.Conn, buf []byte, errCh chan error, stop *uint
 func isTimeout(err error) bool {
 	es := err.Error()
 	esl := len(es)
-	return esl >= ioTimeoutLength && es[esl-ioTimeoutLength:] == ioTimeout
+	if esl >= ioTimeoutLength && es[esl-ioTimeoutLength:] == ioTimeout {
+		return true
+	}
+	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+		return true
+	}
+	return false
 }

--- a/copy.go
+++ b/copy.go
@@ -9,11 +9,6 @@ import (
 	"github.com/getlantern/errors"
 )
 
-const (
-	ioTimeout       = "i/o timeout"
-	ioTimeoutLength = 11
-)
-
 var (
 	copyTimeout = 1 * time.Second
 )
@@ -79,11 +74,6 @@ func doCopy(dst net.Conn, src net.Conn, buf []byte, errCh chan error, stop *uint
 }
 
 func isTimeout(err error) bool {
-	es := err.Error()
-	esl := len(es)
-	if esl >= ioTimeoutLength && es[esl-ioTimeoutLength:] == ioTimeout {
-		return true
-	}
 	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 		return true
 	}

--- a/timeout_bench_test.go
+++ b/timeout_bench_test.go
@@ -9,6 +9,11 @@ import (
 	"testing"
 )
 
+const (
+	ioTimeout       = "i/o timeout"
+	ioTimeoutLength = 11
+)
+
 type timeouterror struct {
 }
 

--- a/timeout_bench_test.go
+++ b/timeout_bench_test.go
@@ -2,6 +2,7 @@ package netx
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"reflect"
 	"strings"
@@ -20,6 +21,21 @@ func (t *timeouterror) Timeout() bool {
 }
 
 func (t *timeouterror) Temporary() bool {
+	return false
+}
+
+type timeouterror2 struct {
+}
+
+func (t *timeouterror2) Error() string {
+	return "unusual message"
+}
+
+func (t *timeouterror2) Timeout() bool {
+	return true
+}
+
+func (t *timeouterror2) Temporary() bool {
 	return false
 }
 
@@ -136,4 +152,103 @@ func hasSuffix(a string, b string, l int) bool {
 		}
 	}
 	return true
+}
+
+func BenchmarkMixedFastPath3x(b *testing.B) {
+	err1 := &timeouterror{}
+	err2 := &timeouterror2{}
+	err3 := context.Canceled
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTimeoutFP(err1)
+		isTimeoutFP(err2)
+		isTimeoutFP(err3)
+	}
+}
+
+func BenchmarkFastPath1(b *testing.B) {
+	err1 := &timeouterror{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTimeoutFP(err1)
+	}
+}
+
+func BenchmarkFastPath2(b *testing.B) {
+	err1 := &timeouterror2{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTimeoutFP(err1)
+	}
+}
+
+func BenchmarkFastPath3(b *testing.B) {
+	err1 := context.Canceled
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTimeoutFP(err1)
+	}
+}
+
+func BenchmarkMixedSlowPath3x(b *testing.B) {
+	err1 := &timeouterror{}
+	err2 := &timeouterror2{}
+	err3 := context.Canceled
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTimeoutSP(err1)
+		isTimeoutSP(err2)
+		isTimeoutSP(err3)
+	}
+}
+
+func BenchmarkSlowPath1(b *testing.B) {
+	err1 := &timeouterror{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTimeoutSP(err1)
+	}
+}
+
+func BenchmarkSlowPath2(b *testing.B) {
+	err1 := &timeouterror2{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTimeoutSP(err1)
+	}
+}
+
+func BenchmarkSlowPath3(b *testing.B) {
+	err1 := context.Canceled
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isTimeoutSP(err1)
+	}
+}
+
+func isTimeoutFP(err error) bool {
+	es := err.Error()
+	esl := len(es)
+	if esl >= ioTimeoutLength && es[esl-ioTimeoutLength:] == ioTimeout {
+		return true
+	}
+	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+		return true
+	}
+	return false
+}
+
+func isTimeoutSP(err error) bool {
+	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
I wrote this with the existing op as a fast path for i/o timeouts ... but it depends on error type ratios whether that's a benefit overall I believe. 

```
BenchmarkTimeoutUsingInterfaceCast-4         	100000000	        16.9 ns/op
BenchmarkTimeoutUsingReflect-4               	200000000	         7.25 ns/op
BenchmarkTimeoutUsingBytesEquals-4           	100000000	        14.4 ns/op
BenchmarkTimeoutUsingHandBuiltCompare-4      	100000000	        14.2 ns/op
BenchmarkTimeoutUsingInterfaceEqualCheck-4   	300000000	         5.13 ns/op
BenchmarkTimeoutUsingSuffix-4                	300000000	         4.55 ns/op
BenchmarkTimeoutUsingSliceCompare-4          	500000000	         3.52 ns/op
BenchmarkTimeoutUsingConcreteCast-4          	2000000000	         0.36 ns/op
BenchmarkTimeoutUsingConcreteEqualCheck-4    	2000000000	         0.35 ns/op
BenchmarkMixedFastPath3x-4                   	30000000	        42.0 ns/op
BenchmarkFastPath1-4                         	300000000	         5.61 ns/op
BenchmarkFastPath2-4                         	100000000	        20.7 ns/op
BenchmarkFastPath3-4                         	100000000	        16.8 ns/op
BenchmarkMixedSlowPath3x-4                   	30000000	        49.9 ns/op
BenchmarkSlowPath1-4                         	100000000	        19.9 ns/op
BenchmarkSlowPath2-4                         	100000000	        19.9 ns/op
BenchmarkSlowPath3-4                         	100000000	        15.9 ns/op
```