### PR TITLE
Harry/localhost fix

### DIFF
--- a/netx.go
+++ b/netx.go
@@ -243,6 +243,12 @@ func resolve(network, addr string) (net.IP, int, error) {
 		ips = ipv4Only(ips)
 	case "tcp6", "udp6":
 		ips = ipv6Only(ips)
+	case "tcp", "udp":
+		if host == "localhost" {
+			// Go servers on localhost will serve over IPv4 only. It's not guaranteed that we
+			// we are resolving a Go server, but it's most likely. IPv4 will likely work anyway.
+			ips = ipv4Only(ips)
+		}
 	}
 	if len(ips) == 0 {
 		return nil, 0, errors.New("unable to resolve IP for %v (%v): %v", host, network, err)


### PR DESCRIPTION
Depends on https://github.com/getlantern/netx/pull/16.

The issue with the current code is that `Resolve("tcp", "localhost")` will make a random choice between "127.0.0.1" or "[::1]".  AFAICT, most applications listening on localhost are only serving one of those addresses, almost always the IPv4 address.  Crucially, a Go server told to listen on localhost will only serve 127.0.0.1.

This is one of the issues plaguing lantern-desktop's `desktop/TestProxying`.  Protocols which use `netx.Resolve` occasionally resolve `localhost` to `[::1]` and cannot reach the local proxy server.

Technically, this change might be wrong for a server listening on `[::1]`.  Really, `Resolve` should probably return all resolved IP addresses and let the caller choose the right one for their needs.  This way, dialers could try IPv4 first, then move on to IPv6.  I believe this is what Go's `net` package does.  I think returning the IPv4 address for localhost should be okay though.  We are unlikely to run into local servers running exclusively over IPv6.