### PR TITLE
Prefer IPv4 when resolving, unless IPv6 is specifically requested

### DIFF
--- a/netx.go
+++ b/netx.go
@@ -243,6 +243,15 @@ func resolve(network, addr string) (net.IP, int, error) {
 		ips = ipv4Only(ips)
 	case "tcp6", "udp6":
 		ips = ipv6Only(ips)
+	case "tcp", "udp":
+		// When the IP version is ambiguous, we prefer IPv4. This is the same choice that Go's net
+		// package makes. Note that localhost can be a special case: for most hosts, the IPv6
+		// address will still reach the server. This is often not the case for localhost; a local
+		// server is likely to only listen over IPv4, but DNS will resolve both the IPv4 and IPv6
+		// addresses. In this case, it can be especially important to prefer IPv4.
+		if ipv4s := ipv4Only(ips); len(ipv4s) > 0 {
+			ips = ipv4s
+		}
 	}
 	if len(ips) == 0 {
 		return nil, 0, errors.New("unable to resolve IP for %v (%v): %v", host, network, err)

--- a/netx_test.go
+++ b/netx_test.go
@@ -1,0 +1,32 @@
+package netx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveLocalhost ensures that localhost resolves to its IPv4 address when the network
+// parameter is ambiguous. This can be important as local servers are unlikely to listen over IPv6
+// except in special cases.
+func TestResolveLocalhost(t *testing.T) {
+	// Try several times as results are randomized.
+	for i := 0; i < 10; i++ {
+		addr, err := Resolve("tcp", "localhost:999")
+		require.NoError(t, err)
+		require.NotNil(t, addr.IP.To4(), "IP (%v) seems to be IPv6, but should be IPv4", addr.IP)
+
+		udpAddr, err := ResolveUDPAddr("udp", "localhost:999")
+		require.NoError(t, err)
+		require.NotNil(t, udpAddr.IP.To4(), "IP (%v) seems to be IPv6, but should be IPv4", udpAddr.IP)
+
+		// Specifying IPv6 should get an IPv6 result.
+		addr, err = Resolve("tcp6", "localhost:999")
+		require.NoError(t, err)
+		require.Nil(t, addr.IP.To4(), "IP (%v) seems to be IPv4, but should be IPv6", addr.IP)
+
+		udpAddr, err = ResolveUDPAddr("udp6", "localhost:999")
+		require.NoError(t, err)
+		require.Nil(t, udpAddr.IP.To4(), "IP (%v) seems to be IPv4, but should be IPv6", udpAddr.IP)
+	}
+}


### PR DESCRIPTION
As suggested [here](https://github.com/getlantern/netx/pull/17#issuecomment-983270280), this amends `Resolve` and `ResolveUDPAddr` to prefer IPv4 addresses unless IPv6 is specifically requested.  As noted in the code comments, this can be particularly important when resolving "localhost" as local servers are unlikely to be listening over IPv6.